### PR TITLE
[TECHNICAL-SUPPORT] LPS-56939 Knowledge Base Display portlet: change of the folder to display is not reflected in the list of articles

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/display/selector/KBFolderKBArticleSelector.java
+++ b/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/display/selector/KBFolderKBArticleSelector.java
@@ -112,13 +112,19 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 
 		KBFolder kbFolder = null;
 
-		if (Validator.isNotNull(preferredKBFolderUrlTitle)) {
+		int kbArticlesCount = KBArticleLocalServiceUtil.getKBArticlesCount(
+			groupId, ancestorKBFolder.getKbFolderId(),
+			WorkflowConstants.STATUS_APPROVED);
+
+		if (Validator.isNotNull(preferredKBFolderUrlTitle) &&
+			(kbArticlesCount == 0)) {
+
 			kbFolder = KBFolderLocalServiceUtil.fetchKBFolderByUrlTitle(
 				groupId, ancestorKBFolder.getKbFolderId(),
 				preferredKBFolderUrlTitle);
 		}
 
-		if (kbFolder == null) {
+		if ((kbFolder == null) && (kbArticlesCount == 0)) {
 			kbFolder = KBFolderLocalServiceUtil.fetchFirstChildKBFolder(
 				groupId, ancestorKBFolder.getKbFolderId());
 		}
@@ -173,7 +179,11 @@ public class KBFolderKBArticleSelector implements KBArticleSelector {
 				preferredKBFolderUrlTitle);
 		}
 
-		if (kbFolder == null) {
+		int kbArticlesCount = KBArticleLocalServiceUtil.getKBArticlesCount(
+			groupId, ancestorKBFolder.getKbFolderId(),
+			WorkflowConstants.STATUS_APPROVED);
+	
+		if ((kbFolder == null) && (kbArticlesCount == 0)) {
 			kbFolder = KBFolderLocalServiceUtil.fetchFirstChildKBFolder(
 				groupId, ancestorKBFolder.getKbFolderId());
 		}


### PR DESCRIPTION
Hey @adolfopa 

I am working on an issue related to the KBArticle selection strategy in Knowledge Base Display portlet.
https://issues.liferay.com/browse/LPS-56939

A customer reported that if a folder is selected for display in the configuration of the portlet, it's entries will not be shown, but the entries of it's child folders if they exist.
This is the case even if the selected folder contains articles.

I saw that this logic was introduced in
https://issues.liferay.com/browse/LPS-52948

where it was explained in a commit message why this logic was chosen

```
LPS-52948 basic selection strategy for KBFolder

When selecting a KBArticle to show in a Display portlet configured with
a KBFolder, the minimum viable strategy is:

  1. Fetch the configured KBFolder.

  2. If it doesn't exist, it means the folder was deleted. By returning
  null, the portlet will be shown in an unconfigured state.

  3. Fetch the requested article. If it doesn't exist, or it isn't a
  descendant of the folder, try to find an article with the same
  friendly URL, or return the first child in the folder (if
  none, return null).

Note that in step 3, when no child exists with the given
kbFolderUrlTitle, we try to show the first child article inside a
subfolder, and if that fails, an article inside the ancestor. This is
needed to avoid showing the portlet in an unconfigured state if someone
uses the wrong friendly URL.
```

However, I found that I could modify the strategy in a way to consider the selected folder first, and only in the case if it contains no articles, should the search proceed to the child folders.
This solution also preserves the validity of the articles URLs.

Please let me know what you think about this.

Thanks!

Best regards,
István