### PR TITLE
[Technical Support] LPS-60882 KB Display suggestion comments extends beyond portlet boundary

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/admin/css/common.scss
+++ b/portlets/knowledge-base-portlet/docroot/admin/css/common.scss
@@ -120,7 +120,7 @@
 			width: 100%;
 
 			.kb-article-comment-body {
-				word-break: normal;
+				word-break: break-word;
 			}
 
 			.kb-article-comment-user {

--- a/portlets/knowledge-base-portlet/docroot/admin/css/common.scss
+++ b/portlets/knowledge-base-portlet/docroot/admin/css/common.scss
@@ -120,7 +120,7 @@
 			width: 100%;
 
 			.kb-article-comment-body {
-				word-break: break-word;
+				word-wrap: break-word;
 			}
 
 			.kb-article-comment-user {


### PR DESCRIPTION
Hey Adolfo

The is a fix for [LPS-60822](https://issues.liferay.com/browse/LPS-60882).

``word-break: break-word`` does not work for some browsers, i.e. FireFox.

See http://caniuse.com/#search=word-break

Let me know if you have any questions

Thanks
John.